### PR TITLE
adds transaction fetch from block, clean up

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,6 @@ readme = "README.md"
 description = "An async library for the Helium blockchain-node JSON_RPC interface"
 authors = ["Kyle Bales <masterjedi@gmail.com>"]
 edition = "2018"
-license = "Apache-2.0"
 license-file = "LICENSE"
 
 [dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,20 +1,23 @@
 [package]
-name = "helium-jsonrpc-rs"
+name = "helium-jsonrpc"
 version = "1.0.1"
 readme = "README.md"
-description = "An async library for the Helium blockchain JSON_RPC interface"
+description = "An async library for the Helium blockchain-node JSON_RPC interface"
 authors = ["Kyle Bales <masterjedi@gmail.com>"]
 edition = "2018"
+license = "Apache-2.0"
+license-file = "LICENSE"
 
 [dependencies]
+async-trait = "0"
+base64 = "0"
+futures = "0"
+helium-api = "3.0.0"
 reqwest = {version = "0", default-features=false, features = ["gzip", "json", "rustls-tls"]}
+rust_decimal = {version = "1", features = ["serde-float"] }
 serde =  {version = "1", features=["derive"]}
 serde_json = "1"
-base64 = "0"
-rust_decimal = {version = "1", features = ["serde-float"] }
 thiserror = "1"
-futures = "0"
-async-trait = "0"
 
 [dev-dependencies]
 tokio = {version = "1", features = ["full"]}

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,6 @@ license-file = "LICENSE"
 async-trait = "0"
 base64 = "0"
 futures = "0"
-helium-api = "3.0.0"
 reqwest = {version = "0", default-features=false, features = ["gzip", "json", "rustls-tls"]}
 rust_decimal = {version = "1", features = ["serde-float"] }
 serde =  {version = "1", features=["derive"]}

--- a/examples/first_block.rs
+++ b/examples/first_block.rs
@@ -1,55 +1,47 @@
+use helium_jsonrpc::{blocks, transactions::Transaction, Client};
 
-use helium_jsonrpc_rs::{ Client, blocks, transactions, transactions::Transaction };
-
-
-//This function will find the first block that blockchain-node has. Should be whatever height the snapshot 
+//This function will find the first block that blockchain-node has. Should be whatever height the snapshot
 //was when the node was first started. May take a while if the node has been running for a long time.
 #[tokio::main]
 async fn main() {
-	let client = helium_jsonrpc_rs::Client::new_with_base_url("http://192.168.2.23:4467".to_string());
-	let first_height = find_first_block(&client).await;
+    let client = Client::new_with_base_url("http://192.168.2.23:4467".to_string());
+    let first_height = find_first_block(&client).await;
 
-	println!("First block: {}", first_height);
-
+    println!("First block: {}", first_height);
 }
 
 async fn find_first_block(client: &Client) -> u64 {
-	let mut current_height = blocks::height(&client).await.unwrap();
-	let mut last_safe_height = current_height; 
-	let mut in_last_epoch = false;
+    let mut current_height = blocks::height(&client).await.unwrap();
+    let mut last_safe_height = current_height;
+    let mut in_last_epoch = false;
 
-	loop {
-		let block = match blocks::get_block(&client, &current_height).await {
-			Ok(b) => b,
-			Err(_) => {
-				if in_last_epoch { 
-					return last_safe_height;
-				}
-				in_last_epoch = true;
-				current_height = last_safe_height-1;
-				blocks::get_block(&client, &current_height).await.unwrap()
-			},
-		};
-		let txns = block.transactions;
+    loop {
+        let block = match blocks::get(&client, &current_height).await {
+            Ok(b) => b,
+            Err(_) if in_last_epoch => return last_safe_height,
+            Err(_) => {
+                in_last_epoch = true;
+                current_height = last_safe_height - 1;
+                blocks::get(&client, &current_height).await.unwrap()
+            }
+        };
+        let res = block.transactions(&client).await;
+        if let Ok(txns) = res {
+            let _ = txns.iter().for_each(|txn| match txn {
+                Transaction::RewardsV2 { start_epoch, .. } => {
+                    current_height = *start_epoch;
+                }
+                _ => {
+                    last_safe_height = current_height;
+                }
+            });
+        } else {
+            println!(
+                "Error fetching transactions for block: {}: {:?}",
+                block.height, res
+            );
+        }
 
-		for tx_hash in txns.iter() {
-			let _tx = match transactions::get_transaction(&client, tx_hash).await {
-				Ok(tx) => match tx {
-					Transaction::RewardsV2{ start_epoch, .. } => {
-						current_height = start_epoch;
-						Ok(())
-					},
-					_ =>{
-						last_safe_height = current_height;
-						Ok(())
-					},
-				},
-				Err(e) => {
-					println!("Error with txn: {}: {:?}", tx_hash, e);
-					Err(e)
-				},
-			};
-		}
-		current_height -= 1;
-	}
+        current_height -= 1;
+    }
 }

--- a/examples/get_block.rs
+++ b/examples/get_block.rs
@@ -1,12 +1,16 @@
-use helium_jsonrpc_rs::{ blocks };
+use helium_jsonrpc::{blocks, Client};
 
 #[tokio::main]
 async fn main() {
-	let height = 873465;
-	let client = helium_jsonrpc_rs::Client::new_with_base_url("http://192.168.1.12:4467".to_string());
-	let block = match blocks::get_block(&client, &height).await {
-		Ok(b) => b, 
-		Err(e) => panic!("Couldn't get block: {}", e),
-	};
-	println!("Found block {} with {} transactions.", height, block.transactions.len());
+    let height = 873465;
+    let client = Client::new_with_base_url("http://192.168.1.12:4467".to_string());
+    let block = match blocks::get(&client, &height).await {
+        Ok(b) => b,
+        Err(e) => panic!("Couldn't get block: {}", e),
+    };
+    println!(
+        "Found block {} with {} transactions.",
+        height,
+        block.transaction_hashes.len()
+    );
 }

--- a/examples/latest_challenge.rs
+++ b/examples/latest_challenge.rs
@@ -1,45 +1,44 @@
-
-use helium_jsonrpc_rs::{ Client, blocks, transactions, transactions::Transaction };
+use helium_jsonrpc::{blocks, transactions, transactions::Transaction, Client};
 
 #[tokio::main]
 async fn main() {
+    let gateway = "11xzD6yrWF2e3oZcLLD6GhjZS7seFoDrG85xqHGxAUUgy4SZCRb";
 
-	let gateway = "11xzD6yrWF2e3oZcLLD6GhjZS7seFoDrG85xqHGxAUUgy4SZCRb";
+    let client = Client::new_with_base_url("http://192.168.1.12:4467".to_string());
 
-	let client = helium_jsonrpc_rs::Client::new_with_base_url("http://192.168.1.12:4467".to_string());
+    let mut current_height = blocks::height(&client).await.unwrap();
 
-	let mut current_height = blocks::height(&client).await.unwrap();
+    loop {
+        let block = match blocks::get(&client, &current_height).await {
+            Ok(b) => b,
+            Err(_) => {
+                panic!("Didn't find challenge..")
+            }
+        };
 
-	loop {
-		let block = match blocks::get_block(&client, &current_height).await {
-			Ok(b) => b,
-			Err(_) => {
-				panic!("Didn't find challenge..")
-			},
-		};
+        let txns = block.transaction_hashes;
 
-		let txns = block.transactions;
-
-		for tx_hash in txns.iter() {
-			let _tx = match transactions::get_transaction(&client, tx_hash).await {
-				Ok(tx) => match tx {
-					Transaction::PocRequestV1{ challenger, .. } => {
-						if challenger == gateway {
-							println!("Most recent challenge issued at block {}. tx {}", current_height, tx_hash);
-							return
-						}
-						Ok(())
-					},
-					_ =>{
-						Ok(())
-					},
-				},
-				Err(e) => {
-					println!("Error with txn: {}: {:?}", tx_hash, e);
-					Err(e)
-				},
-			};
-		}
-		current_height -= 1;
-	}
+        for tx_hash in txns.iter() {
+            let _tx = match transactions::get(&client, tx_hash).await {
+                Ok(tx) => match tx {
+                    Transaction::PocRequestV1 { challenger, .. } => {
+                        if challenger == gateway {
+                            println!(
+                                "Most recent challenge issued at block {}. tx {}",
+                                current_height, tx_hash
+                            );
+                            return;
+                        }
+                        Ok(())
+                    }
+                    _ => Ok(()),
+                },
+                Err(e) => {
+                    println!("Error with txn: {}: {:?}", tx_hash, e);
+                    Err(e)
+                }
+            };
+        }
+        current_height -= 1;
+    }
 }

--- a/src/blocks.rs
+++ b/src/blocks.rs
@@ -10,6 +10,7 @@ pub struct Block {
     pub hash: String,
     pub prev_hash: String,
     pub time: u64,
+    #[serde(rename = "transactions")]
     pub transaction_hashes: Vec<String>,
 }
 

--- a/src/blocks.rs
+++ b/src/blocks.rs
@@ -1,31 +1,41 @@
 use crate::*;
 use serde::{Deserialize, Serialize};
 use serde_json::json;
+use transactions::Transaction;
 
 #[derive(Clone, Serialize, Deserialize, Debug)]
 /// Represents a block response from blockchain-node.
 pub struct Block {
-	pub height: u64,
-	pub hash: String,
-	pub prev_hash: String,
-	pub time: u64,
-	pub transactions: Vec<String>,
+    pub height: u64,
+    pub hash: String,
+    pub prev_hash: String,
+    pub time: u64,
+    pub transaction_hashes: Vec<String>,
 }
 
+impl Block {
+    /// Returns all the transactions in this block
+    pub async fn transactions(&self, client: &Client) -> Result<Vec<Transaction>> {
+        let mut txns: Vec<Transaction> = Vec::new();
+        for hash in &self.transaction_hashes {
+            txns.push(transactions::get(client, &hash).await?);
+        }
+
+        Ok(txns)
+    }
+}
 
 /// Get the current height of the blockchain
 pub async fn height(client: &Client) -> Result<u64> {
-	let json = json!(NodeCall::height());
+    let json = json!(NodeCall::height());
     client.post("/", &json).await?
 }
 
-pub async fn get_block(client: &Client, height: &u64) -> Result<Block> {
-		let json = json!(NodeCall::block(*height));
-		let url_path = "/";
+pub async fn get(client: &Client, height: &u64) -> Result<Block> {
+    let json = json!(NodeCall::block(*height));
+    let url_path = "/";
 
-    client
-        .post(&url_path, &json)
-        .await?
+    client.post(&url_path, &json).await?
 }
 
 #[cfg(test)]
@@ -43,10 +53,7 @@ mod test {
     #[test]
     async fn get_block() {
         let client = Client::default();
-        let block = blocks::get_block(&client, &864203).await.expect("block");
-        assert!(block.transactions.len() > 0);
-        
+        let block = blocks::get(&client, &864203).await.expect("block");
+        assert!(block.transaction_hashes.len() > 0);
     }
-
 }
-

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,13 +1,11 @@
 use thiserror::Error;
 pub type Result<T = ()> = std::result::Result<T, Error>;
 
-
 #[derive(Clone, Debug)]
 pub(crate) struct ErrorElement {
     message: String,
     code: i32,
 }
-
 
 #[derive(Error, Debug)]
 pub enum Error {
@@ -21,7 +19,6 @@ pub enum Error {
     Number(String),
     #[error("error code {1} from node: {0}")]
     NodeError(String, i32),
-
 }
 
 impl Error {

--- a/src/transactions.rs
+++ b/src/transactions.rs
@@ -2,7 +2,6 @@ use crate::*;
 use serde::{Deserialize, Serialize};
 use serde_json::json;
 
-
 #[derive(Clone, Serialize, Deserialize, Debug)]
 pub struct PaymentV2Payment {
     amount: u64,
@@ -34,7 +33,6 @@ pub struct Receipt {
     signal: i64,
     snr: f64,
     timestamp: u64,
-
 }
 
 #[derive(Clone, Serialize, Deserialize, Debug)]
@@ -42,11 +40,10 @@ pub struct PathElement {
     challengee: String,
     receipt: Option<Receipt>,
     witnesses: Vec<Witness>,
-
 }
 
 #[derive(Clone, Serialize, Deserialize, Debug)]
-pub struct Reward{
+pub struct Reward {
     account: Option<String>,
     amount: u64,
     gateway: Option<String>,
@@ -57,20 +54,21 @@ pub struct Reward{
 #[serde(tag = "type", rename_all = "snake_case")]
 /// Represents a transaction response from blockchain-node.
 pub enum Transaction {
-	PocRequestV1 {
-        hash: String, 
+    PocRequestV1 {
+        hash: String,
         block_hash: String,
         challenger: String,
         fee: u64,
         onion_key_hash: String,
         secret_hash: String,
-        version: u64 },
+        version: u64,
+    },
     PaymentV2 {
         hash: String,
         fee: u64,
         nonce: u64,
         payer: String,
-        payments: Vec<PaymentV2Payment>,        
+        payments: Vec<PaymentV2Payment>,
     },
     PocReceiptsV1 {
         hash: String,
@@ -143,15 +141,12 @@ pub enum Transaction {
     Other,
 }
 
+/// Get a specifyc transaction by hash
+pub async fn get(client: &Client, hash: &str) -> Result<Transaction> {
+    let json = json!(NodeCall::transaction(hash.to_string()));
+    let url_path = "/";
 
-
-pub async fn get_transaction(client: &Client, hash: &str) -> Result<Transaction> {
-		let json = json!(NodeCall::transaction(hash.to_string()));
-		let url_path = "/";
-
-    client
-        .post(&url_path, &json)
-        .await?
+    client.post(&url_path, &json).await?
 }
 
 #[cfg(test)]
@@ -162,11 +157,13 @@ mod test {
     #[test]
     async fn txn() {
         let client = Client::default();
-        let txn = transactions::get_transaction(&client, 
-        	"1gidN7e6OKn405Fru_0sGhsqca3lTsrfGKrM4dwM_E8")
-        .await.expect("PocRequestV1");
+        let txn = transactions::get(&client, "1gidN7e6OKn405Fru_0sGhsqca3lTsrfGKrM4dwM_E8")
+            .await
+            .expect("PocRequestV1");
         match txn {
-            Transaction::PocRequestV1{ block_hash, .. } => assert_eq!(block_hash,"RS2mBvd_4pbKCglkkyMroDQekPNO0xDdYx6Te3HGDGg" ),
+            Transaction::PocRequestV1 { block_hash, .. } => {
+                assert_eq!(block_hash, "RS2mBvd_4pbKCglkkyMroDQekPNO0xDdYx6Te3HGDGg")
+            }
             _ => (),
         }
     }
@@ -174,91 +171,104 @@ mod test {
     async fn payment_v2() {
         //dosqfzzaYtoGx278w4Xu5dnYt7aSZIkD1-IbtiiLQQM
         let client = Client::default();
-        let txn = transactions::get_transaction(&client, 
-            "C_jJZLKBOv_gRQ6P6wEpZPiRVAjf44FOx1iHOFD4haA")
-        .await.expect("PaymentV2");
+        let txn = transactions::get(&client, "C_jJZLKBOv_gRQ6P6wEpZPiRVAjf44FOx1iHOFD4haA")
+            .await
+            .expect("PaymentV2");
         match txn {
-            Transaction::PaymentV2{ payments, .. } => assert_eq!(payments.len(), 1),
+            Transaction::PaymentV2 { payments, .. } => assert_eq!(payments.len(), 1),
             _ => (),
         }
     }
     #[test]
     async fn poc_receipts_v1() {
         let client = Client::default();
-        let txn = transactions::get_transaction(&client, 
-            "8RaF-G4pvMVuIXfBYhdqNuIlFSEHPm_rC8TH-h4JYdE")
-        .await.expect("PocReceipt");
+        let txn = transactions::get(&client, "8RaF-G4pvMVuIXfBYhdqNuIlFSEHPm_rC8TH-h4JYdE")
+            .await
+            .expect("PocReceipt");
         match txn {
-            Transaction::PocReceiptsV1{ hash, .. } => assert_eq!(hash, "8RaF-G4pvMVuIXfBYhdqNuIlFSEHPm_rC8TH-h4JYdE"),
+            Transaction::PocReceiptsV1 { hash, .. } => {
+                assert_eq!(hash, "8RaF-G4pvMVuIXfBYhdqNuIlFSEHPm_rC8TH-h4JYdE")
+            }
             _ => (),
         }
     }
     #[test]
     async fn payment_v1() {
         let client = Client::default();
-        let txn = transactions::get_transaction(&client, 
-            "iMSckt_hUcMFY_d7W-QOupY0MGq_g3-CC2dq3P-HWIw")
-        .await.expect("PaymentV1");
+        let txn = transactions::get(&client, "iMSckt_hUcMFY_d7W-QOupY0MGq_g3-CC2dq3P-HWIw")
+            .await
+            .expect("PaymentV1");
         match txn {
-            Transaction::PaymentV1{ payee, .. } => assert_eq!(payee, "14YeKFGXE23yAdACj6hu5NWEcYzzKxptYbm5jHgzw9A1P1UQfMv" ),
+            Transaction::PaymentV1 { payee, .. } => {
+                assert_eq!(payee, "14YeKFGXE23yAdACj6hu5NWEcYzzKxptYbm5jHgzw9A1P1UQfMv")
+            }
             _ => (),
         }
     }
     #[test]
     async fn rewards_v2() {
         let client = Client::default();
-        let txn = transactions::get_transaction(&client,
-            "X0HNRGZ1HAX51CR8qS6LTopAosjFkuaaKXl850IpNDE")
-        .await.expect("RewardsV2");
+        let txn = transactions::get(&client, "X0HNRGZ1HAX51CR8qS6LTopAosjFkuaaKXl850IpNDE")
+            .await
+            .expect("RewardsV2");
         match txn {
-            Transaction::RewardsV2{ rewards, .. } => assert_eq!(rewards.len(), 10138 ),
+            Transaction::RewardsV2 { rewards, .. } => assert_eq!(rewards.len(), 10138),
             _ => (),
         }
     }
     #[test]
     async fn assert_location_v1() {
         let client = Client::default();
-        let txn = transactions::get_transaction(&client,
-            "_I16bycHeltuOo7eyqa4uhv2Bc7awcztZflyvRkVZ24")
-        .await.expect("AssertLocationV1");
+        let txn = transactions::get(&client, "_I16bycHeltuOo7eyqa4uhv2Bc7awcztZflyvRkVZ24")
+            .await
+            .expect("AssertLocationV1");
         match txn {
-            Transaction::AssertLocationV1{ hash, .. } => assert_eq!(hash, "_I16bycHeltuOo7eyqa4uhv2Bc7awcztZflyvRkVZ24"),
+            Transaction::AssertLocationV1 { hash, .. } => {
+                assert_eq!(hash, "_I16bycHeltuOo7eyqa4uhv2Bc7awcztZflyvRkVZ24")
+            }
             _ => (),
         }
     }
     #[test]
     async fn assert_location_v2() {
         let client = Client::default();
-        let txn = transactions::get_transaction(&client,
-            "TfjRv733Q9FBQ1_unw1c9g5ewVmMBuyf7APuyxKEqrw")
-        .await.expect("AssertLocationV2");
+        let txn = transactions::get(&client, "TfjRv733Q9FBQ1_unw1c9g5ewVmMBuyf7APuyxKEqrw")
+            .await
+            .expect("AssertLocationV2");
         match txn {
-            Transaction::AssertLocationV2{ gateway, .. } => assert_eq!(gateway, "112WVxXCrCjiKmmDXLDUJuhYGEHMbXobUZe8oJQkHoMHEFa149a"),
+            Transaction::AssertLocationV2 { gateway, .. } => assert_eq!(
+                gateway,
+                "112WVxXCrCjiKmmDXLDUJuhYGEHMbXobUZe8oJQkHoMHEFa149a"
+            ),
             _ => (),
         }
     }
     #[test]
     async fn add_gateway_v1() {
         let client = Client::default();
-        let txn = transactions::get_transaction(&client,
-            "aoTggHSgaBAamuUUrXnY42jDZ5WUBxE0k-tshvfn35E")
-        .await.expect("AddGatewayV1");
+        let txn = transactions::get(&client, "aoTggHSgaBAamuUUrXnY42jDZ5WUBxE0k-tshvfn35E")
+            .await
+            .expect("AddGatewayV1");
         match txn {
-            Transaction::AddGatewayV1{ gateway, .. } => assert_eq!(gateway, "112uuvztDziVQyLVvBxMsovsSPV5ZXkN6uQ5hrWSaWwV1oEZTZtd"),
+            Transaction::AddGatewayV1 { gateway, .. } => assert_eq!(
+                gateway,
+                "112uuvztDziVQyLVvBxMsovsSPV5ZXkN6uQ5hrWSaWwV1oEZTZtd"
+            ),
             _ => (),
         }
     }
     #[test]
     async fn transfer_hotspot_v1() {
         let client = Client::default();
-        let txn = transactions::get_transaction(&client,
-            "fSFua7A8G41K05QXAvJi5N2OB0QqmQ7xp7u-My4rYHc")
-        .await.expect("TransferHotspotV1");
+        let txn = transactions::get(&client, "fSFua7A8G41K05QXAvJi5N2OB0QqmQ7xp7u-My4rYHc")
+            .await
+            .expect("TransferHotspotV1");
         match txn {
-            Transaction::TransferHotspotV1{  seller, .. } => assert_eq!(seller, "14mo9fFGKYFaWh7xscpDLg7misWcuU5xqR8mc8gHr4c43nDnzeX"),
+            Transaction::TransferHotspotV1 { seller, .. } => assert_eq!(
+                seller,
+                "14mo9fFGKYFaWh7xscpDLg7misWcuU5xqR8mc8gHr4c43nDnzeX"
+            ),
             _ => (),
         }
     }
-
-
 }


### PR DESCRIPTION
This PR does some general idiomatic clean up:
- change crate name, dropping _rs
- Added license info
- rust fmt
-  rename some module fns, removing double naming

Added feature:
- add a impl on Block to return all transactions in one call